### PR TITLE
Modularization of Loss, Optimizer, Tokenizer And add infertence.py

### DIFF
--- a/Template/config.cfg
+++ b/Template/config.cfg
@@ -1,2 +1,6 @@
 [loss]
 loss_name = mse
+
+[optimizer]
+type = AdamW
+learning_rate = 0.00001

--- a/Template/config.cfg
+++ b/Template/config.cfg
@@ -1,0 +1,2 @@
+[loss]
+loss_name = mse

--- a/Template/config.cfg
+++ b/Template/config.cfg
@@ -4,3 +4,7 @@ loss_name = mse
 [optimizer]
 type = AdamW
 learning_rate = 0.00001
+
+[tokenizer]
+model_name = klue/roberta-small
+max_length = 160

--- a/Template/inference.py
+++ b/Template/inference.py
@@ -1,0 +1,70 @@
+import argparse
+import pytorch_lightning as pl
+import pandas as pd
+import torch
+
+'''
+    main 부분에서 저장한 모델의 파일명과 가중치를 직접 지정합니다.
+    저장한 모델의 파일명에 roberta 또는 kcelectra가 포함되어 있다고 가정합니다.
+'''
+
+if __name__ == '__main__':
+    '''
+        model.pt 파일들과 가중치 정보로 앙상블 하여 하나의 output.csv를 만듭니다.
+        parser의 predict_path에 있는 csv파일을 예측합니다.
+    '''
+    # set parser
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--shuffle', default=False)
+    parser.add_argument('--batch_size', default=16, type=int)
+    parser.add_argument('--accelerator', default='gpu')
+    parser.add_argument('--train_path', default='~/data/train.csv')
+    parser.add_argument('--dev_path', default='~/data/dev.csv')
+    parser.add_argument('--test_path', default='~/data/dev.csv')
+    parser.add_argument('--predict_path', default='~/data/test.csv')
+    parser.add_argument('--submission_path', default='~/data/sample_submission.csv')
+    args = parser.parse_args()
+
+    # 불러올 모델들의 pt파일과 해당하는 모델의 가중치를 설정합니다.
+    models = ['exampleRoberta1.pt', 'exampleRoberta2.pt','exampleRoberta3.pt',
+                  'exampleELECTRA1.pt', 'exampleELECTRA2.pt', 'exampleELECTRA3.pt']
+    model_weights = [0.3, 0.1, 0.1, 0.2, 0.2, 0.1]
+
+    prediction = []
+
+    for model_path in models:
+        #모델을 불러옵니다.
+        model = torch.load('./saved/' + model_path)
+
+        # 파일명에 roberta가 있으면 model_name을 klue/roberta-large로 지정합니다
+        if 'roberta' in model_path.lower():
+            model_name = 'klue/roberta-large'
+            # args.batch_size = 16
+
+        # 파일명에 kcelectra가 있으면 model_name을 beomi/KcELECTRA-base-v2022로 지정합니다
+        elif 'kcelectra' in model_path.lower():
+            model_name = 'beomi/KcELECTRA-base-v2022'
+            # args.batch_size = 24
+        else:
+            raise ValueError("Invalid model name")
+
+        # 기존의 Dataloader를 사용합니다.
+        dataloader = Dataloader(model_name, args.batch_size, args.shuffle, args.train_path, args.dev_path,
+                                args.test_path, args.predict_path)
+        
+        # trainer를 설정합니다.
+        trainer = pl.Trainer(accelerator=args.accelerator)
+
+        # predict한 뒤 prediction에 append에 추가합니다
+        prediction.append(torch.cat(trainer.predict(
+            model=model, datamodule=dataloader)))
+        
+    # 가중치를 적용해 앙상블합니다.
+    prediction = torch.stack(prediction).transpose(0, 1)
+    weighted_ensemble = torch.sum(model_weights * prediction, dim=0)
+    
+    # output.csv를 만듭니다.
+    output = pd.read_csv(args.submission_path)
+    output['target'] = weighted_ensemble
+    output['target'] = output['target'].applymap(lambda x: min(max(0.0, x), 5.0))
+    output.to_csv('output.csv', index=False)

--- a/Template/model/loss.py
+++ b/Template/model/loss.py
@@ -1,0 +1,36 @@
+import torch.nn as nn
+
+'''
+    config [loss] 부분의 loss_name 을 바꾸어
+    Model 부분의 self.loss_fn = Loss(config)로 사용할 수 있습니다.
+'''
+
+class Loss(nn.Module):
+    def __init__(self, config):
+        super(Loss, self).__init__()
+        """
+            config로 부터 loss_fn을 설정합니다.
+        """
+        # config에서 loss 함수 이름을 가져옵니다.
+        self.loss_name = config['loss']['loss_name']
+        
+        # loss 함수를 설정합니다.
+        if self.loss_name == 'mse':
+            self.loss_fn = nn.MSELoss()
+        elif self.loss_name == 'l1':
+            self.loss_fn = nn.L1Loss()
+        else:
+            raise ValueError(f"Unsupported loss function: {self.loss_name}")
+        
+    def forward(self, inputs, targets):
+        """
+        loss 값을 계산하는 함수.
+        inputs와 targets을 받아 loss_fn으로 loss를 계산하여 반환. 
+        Args:
+            inputs: 모델이 추론한 예측값.
+            targets: 실제값
+        Returns:
+            loss: loss_fn 계산한 loss값. 
+        """
+        loss = self.loss_fn(inputs, targets)
+        return loss

--- a/Template/model/optimizer.py
+++ b/Template/model/optimizer.py
@@ -1,0 +1,30 @@
+import torch.optim as optim
+'''
+    Model 부분에서 self.optimizer = get_optimizer(self.parameters(), config) 으로 optimizer을 선언 후
+    configure_optimizers에서 return self.optimizer를 해야합니다.
+    만약 스케줄러가 있다면 configure_optimizers에서 return [optimizer], [scheduler] 으로 반환합니다.
+    config에서 optimizer_type의 변경으로 AdamW와 AdamP를 선택합니다.
+'''
+def get_optimizer(model_parameters, config):
+    """
+        config 로 부터 optimizer_type을 읽어 optimizer를 설정합니다.
+        Args:
+            model_parameters: 모델의 파라미터 값.
+            config: config 객체.
+        Returns:
+            optimizer: 설정한 optimizer. 
+    """
+    
+    # config에서 optimizer_type과 learning_rate를 가져옵니다.
+    optimizer_type = config.optimizer.type
+    lr = config.optimizer.learning_rate
+    
+    # optimizer를 설정합니다.
+    if optimizer_type == "AdamP":
+        optimizer = optim.AdamP(model_parameters, lr=lr)
+    elif optimizer_type == "AdamW":
+        optimizer = optim.AdamW(model_parameters, lr=lr)
+    else:
+        raise ValueError("Invalid optimizer type")
+
+    return optimizer

--- a/Template/utils/tokenizer.py
+++ b/Template/utils/tokenizer.py
@@ -1,0 +1,21 @@
+from transformers import AutoTokenizer
+'''
+    Data 부분에서 self.tokenizer = get_tokenizer(config) 으로 tokenizer를 선언합니다.
+    config를 수정하여 model_name 과 max_length를 지정합니다.
+'''
+def get_tokenizer(config):
+    """
+        config 로 부터 model_name과 max_length을 읽어 tokenizer를 설정합니다.
+        Args:
+            config: config 객체.
+        Returns:
+            tokenizer: 설정한 tokenizer. 
+    """
+    # config 파일에서 tokenizer 관련 설정을 가져옵니다
+    model_name = config.tokenizer.model_name
+    max_length = config.tokenizer.max_length
+
+    # tokenizer를 생성합니다.
+    tokenizer = AutoTokenizer.from_pretrained(model_name, max_length=max_length)
+
+    return tokenizer


### PR DESCRIPTION
loss.py : loss 모듈화 
optimizer.py : optimizer 모듈화
tokenizer.py : tokenizer 모듈화 
infertence.py : 가중치를 통한 앙상블 적용
config.cfg에 [loss], [optimizer], [tokenizer] 추가

기존 모듈화 계획에서 조금 달라졌는데 단순히 def로 여러 loss를 만드는 것과 달리
class로 구현하여 기존 Model 부분에서 self.loss_fn = Loss(config) 로 사용하고 config에서 loss_name을 mse 또는 l1 을 입력하여
loss 함수를 정할 수 있다

마찬가지로 optimizer와 tokenizer 도
기존 선언하던 부분에서
self.optimizer = get_optimizer(self.parameters(), config) 
self.tokenizer = get_tokenizer(config)
으로 변경 하고 config.cfg에서 optimizer의 type과 tokenizer의 model_name을 변경하여 사용이 가능하다
